### PR TITLE
Moving style checks to travis

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,8 +1,0 @@
-linters:
-  pep8:
-    python: 3
-    fixer: true
-  shellcheck:
-    shell: bash
-fixers:
-  enable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
     - pip install -r requirements.txt
     - pip install -r requirements/dev.txt
 script:
+    - autopep8 --in-place --aggressive --aggressive -r .
     - python -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ install:
     - pip install -r requirements.txt
     - pip install -r requirements/dev.txt
 script:
-    - autopep8 --in-place --aggressive --aggressive -r .
+    - autopep8 --in-place --aggressive --aggressive -r src
+    - autopep8 --in-place --aggressive --aggressive -r tests
+    - pycodestyle src tests
     - python -m pytest tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM armhf/alpine:latest
 # fix arm build issues on x86 platforms
-# COPY qemu-arm-static /usr/bin
+COPY qemu-arm-static /usr/bin
 
 MAINTAINER Andrew Chang-DeWitt
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,3 @@
 pytest>=5.3.5
-pylint>=2.4.4
+pycodestyle>=2.5.0
+autopep8>=1.5.0

--- a/src/configs.py
+++ b/src/configs.py
@@ -2,6 +2,7 @@ import yaml
 
 from src import sensors
 
+
 class Configs:
     def __init__(self, config_obj):
         self.mqtt_host = config_obj['mqtt_host']
@@ -20,5 +21,5 @@ class Configs:
         with open(config_file, 'r') as stream:
             try:
                 return Configs(yaml.safe_load(stream))
-            except:
+            except BaseException:
                 raise

--- a/src/gpio.py
+++ b/src/gpio.py
@@ -5,6 +5,7 @@ import RPi.GPIO as GPIO
 from src import utils
 from src import sensors
 
+
 class GpioHelper:
     def __init__(self, sensors_list):
         self.input = GPIO.input

--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -4,11 +4,14 @@ import paho.mqtt.client as mqtt
 
 from src import utils
 
+
 class MqttHelper:
     def __init__(self, host, port):
-        mqtt.Client.connected_flag = False # creates connection flag for looping
+        # create connection flag for looping
+        mqtt.Client.connected_flag = False
         self._client = mqtt.Client(socket.gethostname())
-        self._client.on_connect = self._on_connect # binding client connection callback to above fn
+        # binding client connection callback to above fn
+        self._client.on_connect = self._on_connect
         self._MQTT_HOST = host
         self._MQTT_PORT = port
 

--- a/src/sense.py
+++ b/src/sense.py
@@ -13,6 +13,7 @@ from src.mqtt import MqttHelper
 from src.gpio import GpioHelper
 from src.events import Event, Fault
 
+
 class App:
     def __init__(self, error_handler):
         # initilize running variable for tracking quit state
@@ -52,8 +53,9 @@ class App:
 
     def run(self):
         def cb(pin_returned):
-            # wrap callback in a try/except that rethrows errors to the main thread
-            # so that the app doesn't keep chugging along thinking everything is okay
+            # wrap callback in a try/except that rethrows errors to the main
+            # thread so that the app doesn't keep chugging along thinking
+            # everything is okay
             try:
                 return self.event_detected(pin_returned)
             except Exception as e:
@@ -65,7 +67,6 @@ class App:
             self.fault_signal("OK")
             time.sleep(600)
 
-
     def quit(self):
         self.exit = True
 
@@ -75,14 +76,17 @@ class App:
         self.mqtt.disconnect()
         utils.log("rpi-pir2mqtt successfully shut down")
 
+
 def error_handler(exception, cb):
     utils.log("An unexpected error has occurred, exiting app...")
     cb()
     raise exception
 
+
 def sig_handler(signo, _frame):
     utils.log("sig_handler processing quit signal")
     APP.quit()
+
 
 APP = App(error_handler)
 signal.signal(signal.SIGTERM, sig_handler)

--- a/src/sensors.py
+++ b/src/sensors.py
@@ -9,6 +9,7 @@ def build_sensor(sensor):
 
     return types.get(sensor['type'], Sensor)(sensor)
 
+
 class Sensor:
     def __init__(self, data):
         self.name = data['name']

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 
+
 def timestamp():
     return datetime.now().isoformat()
+
 
 def log(msg):
     print(timestamp() + ": " + msg)


### PR DESCRIPTION
Removes `stickler-ci` & replaces it with a first pass by `autopep8` on `src/` & `tests/`, then a check by `pycodestyle` for any linting issues not auto-fixable.